### PR TITLE
Spam-click prevention for Hunger Steal and a Mana Steal bugfix

### DIFF
--- a/src/main/java/net/acetheeldritchking/aces_spell_utils/events/AcesSpellUtilsServerEvents.java
+++ b/src/main/java/net/acetheeldritchking/aces_spell_utils/events/AcesSpellUtilsServerEvents.java
@@ -170,7 +170,6 @@ public class AcesSpellUtilsServerEvents {
         //Check if target is a player for reducing their mana && if the config is enabled
         if (target instanceof ServerPlayer victim && AcesSpellUtilsConfig.manaStealDrain == true)
         {
-            AcesSpellUtils.LOGGER.debug("Mana Steal Player Drain Checks passed");
             var victimMagicData = MagicData.getPlayerMagicData(victim);
             int victimMaxMana = (int) victim.getAttributeValue(AttributeRegistry.MAX_MANA);
             int victimOriginalMana = (int) victimMagicData.getMana();
@@ -198,7 +197,6 @@ public class AcesSpellUtilsServerEvents {
                 AcesSpellUtils.LOGGER.debug("Mana Stolen: " + stolenMana);
             }
         } else {
-            AcesSpellUtils.LOGGER.debug("Mana Steal Player Drain Checks failed");
             //Add "Stolen" mana to Attacker
             int attackerFinalMana = Math.min(attackerOriginalMana + potentialStolenMana, attackerMaxMana);
             attackerMagicData.setMana(attackerFinalMana);

--- a/src/main/java/net/acetheeldritchking/aces_spell_utils/events/AcesSpellUtilsServerEvents.java
+++ b/src/main/java/net/acetheeldritchking/aces_spell_utils/events/AcesSpellUtilsServerEvents.java
@@ -168,37 +168,37 @@ public class AcesSpellUtilsServerEvents {
         int potentialStolenMana = (int) (manaStealAttr * event.getOriginalDamage());
 
         //Check if target is a player for reducing their mana && if the config is enabled
-        if (AcesSpellUtilsConfig.manaStealDrain == true)
+        if (target instanceof ServerPlayer victim && AcesSpellUtilsConfig.manaStealDrain == true)
         {
-            if (target instanceof ServerPlayer victim) {
-                var victimMagicData = MagicData.getPlayerMagicData(victim);
-                int victimMaxMana = (int) victim.getAttributeValue(AttributeRegistry.MAX_MANA);
-                int victimOriginalMana = (int) victimMagicData.getMana();
-                //Final check for applying Mana Steal
-                if (victimMaxMana <= 0) return;
+            AcesSpellUtils.LOGGER.debug("Mana Steal Player Drain Checks passed");
+            var victimMagicData = MagicData.getPlayerMagicData(victim);
+            int victimMaxMana = (int) victim.getAttributeValue(AttributeRegistry.MAX_MANA);
+            int victimOriginalMana = (int) victimMagicData.getMana();
+            //Final check for applying Mana Steal
+            if (victimMaxMana <= 0) return;
 
-                //Calculate how much mana is stolen
-                int stolenMana= Math.min(potentialStolenMana, victimOriginalMana);
+            //Calculate how much mana is stolen
+            int stolenMana= Math.min(potentialStolenMana, victimOriginalMana);
 
-                //Remove stolen mana from victim
-                int victimFinalMana = victimOriginalMana - stolenMana;
-                victimMagicData.setMana(victimFinalMana);
-                PacketDistributor.sendToPlayer(serverPlayer, new SyncManaPacket(victimMagicData));
+            //Remove stolen mana from victim
+            int victimFinalMana = victimOriginalMana - stolenMana;
+            victimMagicData.setMana(victimFinalMana);
+            PacketDistributor.sendToPlayer(serverPlayer, new SyncManaPacket(victimMagicData));
 
-                //Add stolen mana to Attacker
-                int attackerFinalMana = Math.min(attackerOriginalMana + stolenMana, attackerMaxMana);
-                attackerMagicData.setMana(attackerFinalMana);
-                PacketDistributor.sendToPlayer(serverPlayer, new SyncManaPacket(attackerMagicData));
+            //Add stolen mana to Attacker
+            int attackerFinalMana = Math.min(attackerOriginalMana + stolenMana, attackerMaxMana);
+            attackerMagicData.setMana(attackerFinalMana);
+            PacketDistributor.sendToPlayer(serverPlayer, new SyncManaPacket(attackerMagicData));
 
-                if (AcesSpellUtilsConfig.devMode == true)
-                {
-                    AcesSpellUtils.LOGGER.debug("Potential Stolen Mana: " + potentialStolenMana);
-                    AcesSpellUtils.LOGGER.debug("Victim Original Mana: " + victimOriginalMana);
-                    AcesSpellUtils.LOGGER.debug("Attacker Max Mana: " + attackerMaxMana);
-                    AcesSpellUtils.LOGGER.debug("Mana Stolen: " + stolenMana);
-                }
+            if (AcesSpellUtilsConfig.devMode == true)
+            {
+                AcesSpellUtils.LOGGER.debug("Potential Stolen Mana: " + potentialStolenMana);
+                AcesSpellUtils.LOGGER.debug("Victim Original Mana: " + victimOriginalMana);
+                AcesSpellUtils.LOGGER.debug("Attacker Max Mana: " + attackerMaxMana);
+                AcesSpellUtils.LOGGER.debug("Mana Stolen: " + stolenMana);
             }
         } else {
+            AcesSpellUtils.LOGGER.debug("Mana Steal Player Drain Checks failed");
             //Add "Stolen" mana to Attacker
             int attackerFinalMana = Math.min(attackerOriginalMana + potentialStolenMana, attackerMaxMana);
             attackerMagicData.setMana(attackerFinalMana);
@@ -325,8 +325,11 @@ public class AcesSpellUtilsServerEvents {
         //Check if user has hunger steal
         if (hasHungerSteal == null) return;
 
-        double hungerStealAttr = serverPlayer.getAttributeValue(ASAttributeRegistry.HUNGER_STEAL);
+        //Check if attack was made at full charge
+        float weaponCharge = serverPlayer.getAttackStrengthScale(0);
+        if (weaponCharge < 1) return;
 
+        double hungerStealAttr = serverPlayer.getAttributeValue(ASAttributeRegistry.HUNGER_STEAL);
         //Cancels if attributes are 0 to avoid unnecessary calculations
         if (hungerStealAttr <= 0) return;
 


### PR DESCRIPTION
Mana Steal now checks the config and if the target is a player at the same time, so if either of the checks fail it will award the attacking player mana.

Added Spam-click prevention for Hunger Steal